### PR TITLE
feat: uncapping numpy and setuptools versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ from setuptools import find_packages, setup
 
 setup(
     install_requires=[
-        "setuptools>=56,<57",
-        "numpy>=1.20.0,<2",
+        "setuptools>=56",
+        "numpy>=1.20.0,<3",
         "openpyxl>=3.1,<4",
         "pandas>=2.2,<3",
         "scipy>=1.6,<2",


### PR DESCRIPTION
Hello, this would uncap the numpy version being used in HILARy. I took a look at where numpy is being used, and I think there are no aspects of the numpy API being used by HILARy that have changed between numpy 1.2 and numpy 2. It also uncaps the version of setuptools, which I think should be okay to be more flexible than specified, but can cause build issues elsewhere when capped.